### PR TITLE
refactor: remove alejandra in favor of nixfmt

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     # NixOS User Repository
     nur.url = "github:nix-community/NUR";
     ## -- system modules -- ##
-    
+
     ## -- additional modules
     vscode-server.url = "github:nix-community/nixos-vscode-server";
     ## -- additional modules
@@ -27,41 +27,44 @@
     firefox-addons.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    home-manager,
-    flake-utils,
-    nur,
-    vscode-server,
-    nix-vscode-extensions,
-    meanvoid,
-    ...
-  } @ inputs: let
-    inherit (self) outputs;
-  in {
-    # NixOS configuration entrypoint
-    # Available through 'nixos-rebuild --flake .#your-hostname'
-    nixosConfigurations = {
-      nixos = nixpkgs.lib.nixosSystem {
-        specialArgs = {inherit inputs outputs;};
-        # > Our main nixos configuration file <
-        modules = [
-          ./nixos/configuration.nix
-        ];
+  outputs =
+    {
+      self,
+      nixpkgs,
+      home-manager,
+      flake-utils,
+      nur,
+      vscode-server,
+      nix-vscode-extensions,
+      meanvoid,
+      ...
+    }@inputs:
+    let
+      inherit (self) outputs;
+    in
+    {
+      # NixOS configuration entrypoint
+      # Available through 'nixos-rebuild --flake .#your-hostname'
+      nixosConfigurations = {
+        nixos = nixpkgs.lib.nixosSystem {
+          specialArgs = {
+            inherit inputs outputs;
+          };
+          # > Our main nixos configuration file <
+          modules = [ ./nixos/configuration.nix ];
+        };
       };
-    };
 
-    # Standalone home-manager configuration entrypoint
-    # Available through 'home-manager --flake .#your-username@your-hostname'
-    homeConfigurations = {
-      "kunny@nixos" = home-manager.lib.homeManagerConfiguration {
-        pkgs = nixpkgs.legacyPackages.x86_64-linux;
-        extraSpecialArgs = {inherit inputs outputs;};
-        modules = [
-          ./home-manager/home.nix
-        ];
+      # Standalone home-manager configuration entrypoint
+      # Available through 'home-manager --flake .#your-username@your-hostname'
+      homeConfigurations = {
+        "kunny@nixos" = home-manager.lib.homeManagerConfiguration {
+          pkgs = nixpkgs.legacyPackages.x86_64-linux;
+          extraSpecialArgs = {
+            inherit inputs outputs;
+          };
+          modules = [ ./home-manager/home.nix ];
+        };
       };
     };
-  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,29 +1,33 @@
 {
-  description = "My NixOS Flake";
+  description = "My NixOS system configuration";
 
   inputs = {
-    # Nixpkgs
-    nixpkgs.url = "github:nixos/nixpkgs/";
-
-    # Home manager
+    ## -- system modules --  ##
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     home-manager.url = "github:nix-community/home-manager";
-    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+    # NixOS User Repository
+    nur.url = "github:nix-community/NUR";
+    ## -- system modules -- ##
+    
+    ## -- additional modules
+    vscode-server.url = "github:nix-community/nixos-vscode-server";
+    ## -- additional modules
 
     alejandra.url = "github:kamadorueda/alejandra/3.0.0";
-    alejandra.inputs.nixpkgs.follows = "nixpkgs";
 
-    nur.url = "github:nix-community/NUR";
-
-    vscode-server.url = "github:nix-community/nixos-vscode-server";
-    vscode-server.inputs.nixpkgs.follows = "nixpkgs";
+    # vscode extensions set of packages(nixpkgs doesn't contain needed extensions)
     nix-vscode-extensions.url = "github:nix-community/nix-vscode-extensions";
-    nix-vscode-extensions.inputs.nixpkgs.follows = "nixpkgs";
-
+    # firefox addons set of packages
     firefox-addons.url = "gitlab:rycee/nur-expressions?dir=pkgs/firefox-addons";
-    firefox-addons.inputs.nixpkgs.follows = "nixpkgs";
-
-    # Meanvoid - 2hu cursors
+    # @ashuramaruzxc/@meanvoid - Touhou Project and other anime-styled cursors
     meanvoid.url = "github:meanvoid/nixos-overlay";
+
+    # Redefinitions
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+    alejandra.inputs.nixpkgs.follows = "nixpkgs";
+    vscode-server.inputs.nixpkgs.follows = "nixpkgs";
+    nix-vscode-extensions.inputs.nixpkgs.follows = "nixpkgs";
+    firefox-addons.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = {

--- a/flake.nix
+++ b/flake.nix
@@ -13,8 +13,6 @@
     vscode-server.url = "github:nix-community/nixos-vscode-server";
     ## -- additional modules
 
-    alejandra.url = "github:kamadorueda/alejandra/3.0.0";
-
     # vscode extensions set of packages(nixpkgs doesn't contain needed extensions)
     nix-vscode-extensions.url = "github:nix-community/nix-vscode-extensions";
     # firefox addons set of packages
@@ -24,7 +22,6 @@
 
     # Redefinitions
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
-    alejandra.inputs.nixpkgs.follows = "nixpkgs";
     vscode-server.inputs.nixpkgs.follows = "nixpkgs";
     nix-vscode-extensions.inputs.nixpkgs.follows = "nixpkgs";
     firefox-addons.inputs.nixpkgs.follows = "nixpkgs";
@@ -36,7 +33,6 @@
     home-manager,
     flake-utils,
     nur,
-    alejandra,
     vscode-server,
     nix-vscode-extensions,
     meanvoid,

--- a/home-manager/programs/chromium.nix
+++ b/home-manager/programs/chromium.nix
@@ -1,21 +1,22 @@
-{pkgs, ...}: {
+{ pkgs, ... }:
+{
   programs.chromium = {
     enable = true;
     package = pkgs.brave;
-    dictionaries = [pkgs.hunspellDictsChromium.en_US];
+    dictionaries = [ pkgs.hunspellDictsChromium.en_US ];
     extensions = [
-      {id = "ohnjgmpcibpbafdlkimncjhflgedgpam";} # 4ChudX
-      {id = "cjpalhdlnbpafiamejdnhcphjbkeiagm";} # Ublock Origin
-      {id = "nngceckbapebfimnlniiiahkandclblb";} # Bitwarden
-      {id = "eimadpbcbfnmbkopoojfekhnkhdbieeh";} # Dark Reader
-      {id = "mnjggcdmjocbbbhaepdhchncahnbgone";} # Sponsor Block
-      {id = "ejonaglbdpcfkgbcnidjlnjogfdgbofp";} # Modern-Scroll
-      {id = "enamippconapkdmgfgjchkhakpfinmaj";} # Dearrow
-      {id = "gebbhagfogifgggkldgodflihgfeippi";} # Return YT Dislikes
-      {id = "pobhoodpcipjmedfenaigbeloiidbflp";} # Minimal Twitta Theme
-      {id = "hfjbmagddngcpeloejdejnfgbamkjaeg";} # Vimium C
-      {id = "lcpclaffcdiihapebmfgcmmplphbkjmd";} # No youtube maxxing
-      {id = "jiaopdjbehhjgokpphdfgmapkobbnmjp";} # attention maxxing
+      { id = "ohnjgmpcibpbafdlkimncjhflgedgpam"; } # 4ChudX
+      { id = "cjpalhdlnbpafiamejdnhcphjbkeiagm"; } # Ublock Origin
+      { id = "nngceckbapebfimnlniiiahkandclblb"; } # Bitwarden
+      { id = "eimadpbcbfnmbkopoojfekhnkhdbieeh"; } # Dark Reader
+      { id = "mnjggcdmjocbbbhaepdhchncahnbgone"; } # Sponsor Block
+      { id = "ejonaglbdpcfkgbcnidjlnjogfdgbofp"; } # Modern-Scroll
+      { id = "enamippconapkdmgfgjchkhakpfinmaj"; } # Dearrow
+      { id = "gebbhagfogifgggkldgodflihgfeippi"; } # Return YT Dislikes
+      { id = "pobhoodpcipjmedfenaigbeloiidbflp"; } # Minimal Twitta Theme
+      { id = "hfjbmagddngcpeloejdejnfgbamkjaeg"; } # Vimium C
+      { id = "lcpclaffcdiihapebmfgcmmplphbkjmd"; } # No youtube maxxing
+      { id = "jiaopdjbehhjgokpphdfgmapkobbnmjp"; } # attention maxxing
     ];
   };
 }

--- a/home-manager/programs/firefox.nix
+++ b/home-manager/programs/firefox.nix
@@ -1,15 +1,11 @@
+{ pkgs, inputs, ... }:
 {
-  pkgs,
-  inputs,
-  ...
-}: {
   programs.firefox = {
     enable = true;
     profiles.main = {
       isDefault = true;
       extensions = builtins.attrValues {
-        inherit
-          (inputs.firefox-addons.packages.${pkgs.system})
+        inherit (inputs.firefox-addons.packages.${pkgs.system})
           ublock-origin
           tree-style-tab
           sponsorblock

--- a/home-manager/programs/kde-connect.nix
+++ b/home-manager/programs/kde-connect.nix
@@ -1,3 +1,1 @@
-_: {
-  services.kdeconnect.enable = true;
-}
+_: { services.kdeconnect.enable = true; }

--- a/home-manager/programs/nvim/default.nix
+++ b/home-manager/programs/nvim/default.nix
@@ -1,4 +1,5 @@
-{pkgs, ...}: {
+{ pkgs, ... }:
+{
   programs.neovim = {
     enable = true;
     viAlias = true;
@@ -13,8 +14,7 @@
         plugin = pkgs.vimPlugins.deoplete-nvim;
         config = "let g:deoplete#enable_at_startup = 1";
       };
-      inherit
-        (pkgs.vimPlugins)
+      inherit (pkgs.vimPlugins)
         lightline-vim
         vim-markdown
         gruvbox

--- a/home-manager/programs/packages.nix
+++ b/home-manager/programs/packages.nix
@@ -1,9 +1,9 @@
-{pkgs, ...}: {
+{ pkgs, ... }:
+{
   home.packages = builtins.attrValues {
-    inherit
-      (pkgs)
+    inherit (pkgs)
       # CLI
-      
+
       eza
       tldr
       tree
@@ -21,52 +21,50 @@
       bat
       pandoc
       # Programming
-      
+
       github-cli
       git
       python310
       #gcc
-      
+
       clang_12
       clang-tools_12
       cmake
       # SDK
-      
+
       nodejs
       openjdk
       # videos
-      
+
       ffmpeg_5
       mpv
       vlc
       # Social
-      
+
       thunderbird
       tdesktop
       nheko
       vesktop
       # Sound
-      
+
       pavucontrol
       qpwgraph
       # torrent
-      
+
       qbittorrent
       ;
 
     # windows
     wineWow-stable = pkgs.wineWowPackages.stable;
-    inherit
-      (pkgs)
+    inherit (pkgs)
       winetricks
       # educational
-      
+
       onlyoffice-bin
       zoom-us
       ;
     tex = pkgs.texlive.combine {
-      inherit
-        (pkgs.texlive)
+      inherit (pkgs.texlive)
         scheme-tetex
         latexmk
         enumitem
@@ -80,10 +78,9 @@
     };
     inherit (pkgs) gImageReader;
     okular = pkgs.libsForQt5.okular;
-    inherit
-      (pkgs)
+    inherit (pkgs)
       # obsidian
-      
+
       anki
       ;
 
@@ -92,10 +89,9 @@
     ark = pkgs.libsForQt5.ark;
     kolourpaint = pkgs.libsForQt5.kolourpaint;
 
-    inherit
-      (pkgs)
+    inherit (pkgs)
       # other
-      
+
       teamviewer
       brave
       microsoft-edge
@@ -104,7 +100,7 @@
       bitwarden
       tor-browser-bundle-bin
       # network
-      
+
       riseup-vpn
       calyx-vpn
       networkmanager-openvpn

--- a/home-manager/programs/vscode/extensions.nix
+++ b/home-manager/programs/vscode/extensions.nix
@@ -1,11 +1,15 @@
+{ pkgs, inputs, ... }:
+let
+  inherit
+    (inputs.nix-vscode-extensions.extensions.${pkgs.system}.forVSCodeVersion pkgs.vscode.version)
+    vscode-marketplace
+    ;
+  inherit
+    (inputs.nix-vscode-extensions.extensions.${pkgs.system}.forVSCodeVersion pkgs.vscode.version)
+    vscode-marketplace-release
+    ;
+in
 {
-  pkgs,
-  inputs,
-  ...
-}: let
-  inherit (inputs.nix-vscode-extensions.extensions.${pkgs.system}.forVSCodeVersion pkgs.vscode.version) vscode-marketplace;
-  inherit (inputs.nix-vscode-extensions.extensions.${pkgs.system}.forVSCodeVersion pkgs.vscode.version) vscode-marketplace-release;
-in {
   programs.vscode.extensions = builtins.attrValues {
     vscode-remote-extensionpack = vscode-marketplace.ms-vscode-remote.vscode-remote-extensionpack;
     vscode-icons = vscode-marketplace.vscode-icons-team.vscode-icons;

--- a/home-manager/programs/vscode/extensions.nix
+++ b/home-manager/programs/vscode/extensions.nix
@@ -16,7 +16,7 @@ in {
 
     bbenoist-nix = vscode-marketplace.bbenoist.nix;
     nix-ide = vscode-marketplace.jnoortheen.nix-ide;
-    kamadorueda-alejandra = vscode-marketplace.kamadorueda.alejandra;
+    brettm12345-nixfmt-vscode = vscode-marketplace.brettm12345.nixfmt-vscode;
 
     python = vscode-marketplace.ms-python.python;
     vscode-pylance = vscode-marketplace.ms-python.vscode-pylance;

--- a/home-manager/programs/vscode/settings.nix
+++ b/home-manager/programs/vscode/settings.nix
@@ -6,7 +6,7 @@ _: {
     "editor.fontSize" = 16;
     "editor.cursorSurroundingLines" = 6;
     "editor.fontFamily" = "'Comic Mono', 'monospace', monospace";
-    "editor.rulers" = [80];
+    "editor.rulers" = [ 80 ];
     "editor.minimap.enabled" = false;
     "editor.mouseWheelZoom" = true;
     "editor.guides.bracketPairs" = "active";

--- a/home-manager/programs/vscode/settings.nix
+++ b/home-manager/programs/vscode/settings.nix
@@ -42,12 +42,11 @@ _: {
     };
 
     "[nix]" = {
-      "editor.defaultFormatter" = "kamadorueda.alejandra";
+      "editor.defaultFormatter" = "brettm12345.nixfmt-vscode";
       "editor.formatOnPaste" = true;
       "editor.formatOnSave" = true;
       "editor.formatOnType" = false;
     };
-    "alejandra.program" = "alejandra";
 
     "github.copilot.enable" = {
       "*" = true;

--- a/home-manager/programs/zsh.nix
+++ b/home-manager/programs/zsh.nix
@@ -1,4 +1,4 @@
-{pkgs, ...}: {
+_: {
   programs.zsh = {
     enable = true;
     autosuggestion.enable = true;

--- a/nixos/configs/fonts.nix
+++ b/nixos/configs/fonts.nix
@@ -1,40 +1,51 @@
+# Special thanks to @ashuramaruzxc for this fix
 {
   pkgs,
   lib,
   config,
   ...
-}: {
-  system.fsPackages = [pkgs.bindfs];
+}:
+{
+  system.fsPackages = [ pkgs.bindfs ];
   fileSystems =
     lib.mapAttrs
-    (_: v:
-      v
-      // {
-        fsType = "fuse.bindfs";
-        options = ["ro" "resolve-symlinks" "x-gvfs-hide"];
-      })
-    {
-      # "/usr/share/icons".device = "/run/current-system/sw/share/icons";
-      "/usr/share/fonts".device =
-        pkgs.buildEnv
-        {
-          name = "system-fonts";
-          paths = config.fonts.packages;
-          pathsToLink = ["/share/fonts"];
+      (
+        _: v:
+        v
+        // {
+          fsType = "fuse.bindfs";
+          options = [
+            "ro"
+            "resolve-symlinks"
+            "x-gvfs-hide"
+          ];
         }
-        + "/share/fonts";
-    };
+      )
+      {
+        # "/usr/share/icons".device = "/run/current-system/sw/share/icons";
+        "/usr/share/fonts".device =
+          pkgs.buildEnv {
+            name = "system-fonts";
+            paths = config.fonts.packages;
+            pathsToLink = [ "/share/fonts" ];
+          }
+          + "/share/fonts";
+      };
 
   fonts.packages = builtins.attrValues {
-    inherit
-      (pkgs)
+    inherit (pkgs)
       comic-mono
       hack-font
       noto-fonts
       noto-fonts-cjk
       noto-fonts-emoji
       ;
-    nerdfonts = pkgs.nerdfonts.override {fonts = ["FiraCode" "DroidSansMono"];};
+    nerdfonts = pkgs.nerdfonts.override {
+      fonts = [
+        "FiraCode"
+        "DroidSansMono"
+      ];
+    };
   };
   fonts.fontDir.enable = true;
 }

--- a/nixos/configs/input.nix
+++ b/nixos/configs/input.nix
@@ -1,4 +1,5 @@
-{pkgs, ...}: {
+{ pkgs, ... }:
+{
   environment.sessionVariables = {
     GTK_IM_MODULE = "fcitx";
     QT_IM_MODULE = "fcitx";
@@ -8,7 +9,6 @@
   i18n = {
     inputMethod = {
       enabled = "fcitx5";
-      # fcitx.engines = with pkgs.fcitx-engines; [ mozc unikey ];
       fcitx5.addons = builtins.attrValues {
         inherit (pkgs) fcitx5-mozc fcitx5-unikey;
         fcitx5-qt = pkgs.libsForQt5.fcitx5-qt;

--- a/nixos/configs/program-config.nix
+++ b/nixos/configs/program-config.nix
@@ -1,4 +1,5 @@
-{pkgs, ...}: {
+{ pkgs, ... }:
+{
   programs.htop.enable = true;
   programs.nano.syntaxHighlight = true;
 

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -6,7 +6,8 @@
   config,
   pkgs,
   ...
-}: {
+}:
+{
   # You can import other NixOS modules here
   imports = [
     ./hardware-configuration.nix
@@ -18,7 +19,7 @@
   ];
 
   nixpkgs = {
-    overlays = [];
+    overlays = [ ];
     config = {
       allowUnfree = true;
     };
@@ -26,18 +27,17 @@
 
   # This will add each flake input as a registry
   # To make nix3 commands consistent with your flake
-  nix.registry = (lib.mapAttrs (_: flake: {inherit flake;})) ((lib.filterAttrs (_: lib.isType "flake")) inputs);
+  nix.registry = (lib.mapAttrs (_: flake: { inherit flake; })) (
+    (lib.filterAttrs (_: lib.isType "flake")) inputs
+  );
 
   # This will additionally add your inputs to the system's legacy channels
   # Making legacy nix commands consistent as well, awesome!
-  nix.nixPath = ["/etc/nix/path"];
-  environment.etc =
-    lib.mapAttrs'
-    (name: value: {
-      name = "nix/path/${name}";
-      value.source = value.flake;
-    })
-    config.nix.registry;
+  nix.nixPath = [ "/etc/nix/path" ];
+  environment.etc = lib.mapAttrs' (name: value: {
+    name = "nix/path/${name}";
+    value.source = value.flake;
+  }) config.nix.registry;
 
   nix.settings = {
     # Enable flakes and new 'nix' command
@@ -61,9 +61,7 @@
   networking.hostName = "nixos";
   networking.networkmanager = {
     enable = true;
-    plugins = builtins.attrValues {
-      inherit (pkgs) networkmanager-openvpn;
-    };
+    plugins = builtins.attrValues { inherit (pkgs) networkmanager-openvpn; };
   };
 
   # Set your time zone.
@@ -78,15 +76,19 @@
 
   # Fonts
   fonts.packages = builtins.attrValues {
-    inherit
-      (pkgs)
+    inherit (pkgs)
       comic-mono
       hack-font
       noto-fonts
       noto-fonts-cjk
       noto-fonts-emoji
       ;
-    nerdfonts = pkgs.nerdfonts.override {fonts = ["FiraCode" "DroidSansMono"];};
+    nerdfonts = pkgs.nerdfonts.override {
+      fonts = [
+        "FiraCode"
+        "DroidSansMono"
+      ];
+    };
   };
   fonts.fontDir.enable = true;
 
@@ -124,8 +126,13 @@
   users.users = {
     kunny = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [];
-      extraGroups = ["networkmanager" "wheel" "docker" "libvirtd"];
+      openssh.authorizedKeys.keys = [ ];
+      extraGroups = [
+        "networkmanager"
+        "wheel"
+        "docker"
+        "libvirtd"
+      ];
     };
   };
 

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -5,24 +5,29 @@
   nur,
   home-manager,
   ...
-}: let
+}:
+let
   system = "x86_64-linux";
-  specialArgs = {inherit inputs;};
+  specialArgs = {
+    inherit inputs;
+  };
   modules = [
     # > Our main NixOS configuration file <
     ./configuration.nix
 
     nur.nixosModules.nur
 
-    {nixpkgs.overlays = [nur.overlay];}
-    ({pkgs, ...}: let
-      nur-no-pkgs = import nur {
-        nurpkgs = import nixpkgs {system = "x86_64-linux";};
-      };
-    in {
-      imports = [nur-no-pkgs.repos.iopq.modules.xraya];
-      services.xraya.enable = true;
-    })
+    { nixpkgs.overlays = [ nur.overlay ]; }
+    (
+      { pkgs, ... }:
+      let
+        nur-no-pkgs = import nur { nurpkgs = import nixpkgs { system = "x86_64-linux"; }; };
+      in
+      {
+        imports = [ nur-no-pkgs.repos.iopq.modules.xraya ];
+        services.xraya.enable = true;
+      }
+    )
 
     home-manager.nixosModules.home-manager
     {
@@ -30,11 +35,14 @@
         useGlobalPkgs = true;
         useUserPackages = true;
         users.kunny = import ../home-manager/home.nix;
-        extraSpecialArgs = {inherit inputs outputs system;};
+        extraSpecialArgs = {
+          inherit inputs outputs system;
+        };
       };
     }
   ];
-in {
+in
+{
   kunny = inputs.nixpkgs.lib.nixosSystem {
     inherit system;
     inherit specialArgs;

--- a/nixos/hardware-configuration.nix
+++ b/nixos/hardware-configuration.nix
@@ -4,18 +4,22 @@
 {
   config,
   lib,
-  pkgs,
   modulesPath,
   ...
-}: {
-  imports = [
-    (modulesPath + "/installer/scan/not-detected.nix")
-  ];
+}:
+{
+  imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
 
-  boot.initrd.availableKernelModules = ["nvme" "xhci_pci" "ahci" "usb_storage" "sd_mod"];
-  boot.initrd.kernelModules = [];
-  boot.kernelModules = ["kvm-amd"];
-  boot.extraModulePackages = [];
+  boot.initrd.availableKernelModules = [
+    "nvme"
+    "xhci_pci"
+    "ahci"
+    "usb_storage"
+    "sd_mod"
+  ];
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ "kvm-amd" ];
+  boot.extraModulePackages = [ ];
 
   fileSystems."/" = {
     device = "/dev/disk/by-uuid/db539d62-a0f2-468e-b99e-28d2f1818dbd";
@@ -29,9 +33,7 @@
     fsType = "vfat";
   };
 
-  swapDevices = [
-    {device = "/dev/disk/by-uuid/f9b21383-5c2d-431c-a504-484110bb18bd";}
-  ];
+  swapDevices = [ { device = "/dev/disk/by-uuid/f9b21383-5c2d-431c-a504-484110bb18bd"; } ];
 
   # Enables DHCP on each ethernet and wireless interface. In case of scripted networking
   # (the default) this is the recommended approach. When using systemd-networkd it's


### PR DESCRIPTION
## Changes
- rephrased: `flake.nix` description to something more suitable
- update: use [nixos-unstable](https://hydra.nixos.org/job/nixos/trunk-combined/tested#tabs-constituents) branch instead of `master` branch
- refactor: moved inputs's nixpkgs redeclaration
- refactor: removed alejandra as formatter in favor of nixfmt